### PR TITLE
Fixes #13

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -45,7 +45,7 @@ def custom_wordcount(syntax,):
 # the function will just strip off any comments and markup and then
 # call basic_wordcount() with the remaining cleaned-up string
 
-latex_comment = re.compile("\n?%.*", re.MULTILINE)
+latex_comment = re.compile("\n?(?<!\\\\)%.*", re.MULTILINE)
 latex_lformula = re.compile(r"\$\$.*?\$\$", re.MULTILINE | re.DOTALL)
 latex_sformula = re.compile(r"\$.*?\$", re.MULTILINE)
 latex_abstract = re.compile(


### PR DESCRIPTION
Changed the regex for detecting comments so that it excludes text that has an escaped percent symbol. Previously, text with a percent sign was not counted because it was incorrectly treated as a comment.